### PR TITLE
[GG-36948] Adjust CODEOWNERS in accordance with the new teams structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 # the following github users/groups will be added to PR as reviewers automatically
 # see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-*       @getgoing/zulu
-
-.drone.star	@getgoing/ops
+*            @getgoing/zulu_be


### PR DESCRIPTION
Note that CODEOWNERS was also moved into a .github folder

The corresponding table: https://docs.google.com/spreadsheets/d/1VOcWaiDBaMT61hX1LuiNn7-FrELvRffSKimvSOm3fSE/edit?gid=0#gid=0

Ticket: https://getgoing.atlassian.net/browse/GG-36948
